### PR TITLE
forbedre logging av error og forenkling av resttemplate feilhåndtering

### DIFF
--- a/src/main/kotlin/no/nav/tag/innsynAareg/client/altinn/AltinnClient.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/client/altinn/AltinnClient.kt
@@ -73,10 +73,9 @@ class AltinnClient(
                 }
                 .let { AltinnOppslagVellykket(it) }
         } catch (error: Exception) {
-            logger.error("AG-ARBEIDSFORHOLD Klarte ikke hente organisasjoner fra altinn.", error)
             if (error.message?.contains("403") == true)
                 AltinnIngenRettigheter
             else
-                throw error
+                throw RuntimeException("AG-ARBEIDSFORHOLD Klarte ikke hente organisasjoner fra altinn. $error", error)
         }
 }

--- a/src/main/kotlin/no/nav/tag/innsynAareg/client/pdl/PdlBatchClient.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/client/pdl/PdlBatchClient.kt
@@ -28,23 +28,19 @@ class PdlBatchClient @Autowired constructor(
                 .message
                 .toString()
                 .replace(Regex("""\d{11}"""), "***********")
-            log.error("AG-ARBEIDSFORHOLD feiler mot PDL ", msg)
+            log.error("AG-ARBEIDSFORHOLD feiler mot PDL: $msg")
             null
         }
     }
 
     private fun getBatchFraPdlInternal(fnrs: List<String>): HentPersonBolkResponse {
-        val stsToken: String? = stsClient.token?.access_token
-        val headers = HttpHeaders()
+        val stsToken: String = stsClient.token.access_token
 
-        if (stsToken != null) {
-            headers.setBearerAuth(stsToken)
-        } else {
-            log.error("fant ikke ststoken i pdlservice")
-        }
+        val headers = HttpHeaders()
         headers.contentType = MediaType.APPLICATION_JSON
         headers["Tema"] = "GEN"
         headers["Nav-Consumer-Token"] = "Bearer $stsToken"
+        headers.setBearerAuth(stsToken)
 
         return restTemplate.postForObject(
             pdlUrl,

--- a/src/main/kotlin/no/nav/tag/innsynAareg/client/sts/STSClient.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/client/sts/STSClient.kt
@@ -20,20 +20,10 @@ constructor(
     private val requestEntity = getRequestEntity(stsPass)
     private val uriString = buildUriString(stsUrl)
 
-    val token: STStoken?
+    val token: STStoken
         @Cacheable(STS_CACHE)
         get() {
-            try {
-                val response = restTemplate.exchange(uriString, HttpMethod.GET, requestEntity, STStoken::class.java)
-                if (response.statusCode != HttpStatus.OK) {
-                    val message = "Kall mot STS feiler med HTTP-" + response.statusCode
-                    throw RuntimeException(message)
-                }
-                return response.body
-            } catch (e: Throwable) {
-                //log.error("Feil ved oppslag i STS", e)
-                throw RuntimeException(e)
-            }
+            return restTemplate.exchange(uriString, HttpMethod.GET, requestEntity, STStoken::class.java).body!!
         }
 
 

--- a/src/main/kotlin/no/nav/tag/innsynAareg/client/sts/STStoken.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/client/sts/STStoken.kt
@@ -1,9 +1,9 @@
 package no.nav.tag.innsynAareg.client.sts
 
 @Suppress("Unused") /* dto */
-class STStoken {
-    var access_token: String? = null
-    internal var token_type: String? = null
-    internal var expires_in: Int = 0
-}
+data class STStoken(
+    var access_token: String,
+    var token_type: String? = null,
+    var expires_in: Int = 0,
+)
 

--- a/src/main/kotlin/no/nav/tag/innsynAareg/client/yrkeskoder/dto/Yrkeskoderespons.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/client/yrkeskoder/dto/Yrkeskoderespons.kt
@@ -3,6 +3,6 @@ package no.nav.tag.innsynAareg.client.yrkeskoder.dto
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class Yrkeskoderespons {
-    val betydninger = hashMapOf<String, List<Yrkeskode>>()
-}
+data class Yrkeskoderespons(
+    val betydninger : Map<String, List<Yrkeskode>> = hashMapOf()
+)

--- a/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
@@ -42,7 +42,6 @@ class InnsynService(
 
         val orgtreFraEnhetsregisteret = enhetsregisteretService
             .hentOrganisasjonFraEnhetsregisteret(orgnrUnderenhet, false)
-            ?: throw RuntimeException("enhetsregisteret frant ingen organisasjon med orgnummer $orgnrUnderenhet")
 
         if (orgtreFraEnhetsregisteret.bestaarAvOrganisasjonsledd.isNullOrEmpty()) {
             return Pair(orgnrHovedenhet, 0)
@@ -55,8 +54,7 @@ class InnsynService(
                 idPortenToken
             )
         } catch (exception: Exception) {
-            logger.error("Klarte ikke itere over orgtre ", exception.message)
-            throw AaregException(" Aareg Exception, klarte ikke finne opplysningspliktig: $exception")
+            throw AaregException("Aareg Exception, klarte ikke finne opplysningspliktig: $exception", exception)
         }
     }
 
@@ -81,8 +79,8 @@ class InnsynService(
                     idToken
                 )
                 return Pair(juridiskEnhetOrgnr, antallNesteNiva!!)
-            } catch (exception: Exception) {
-                throw AaregException(" Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: $exception")
+            } catch (e: Exception) {
+                throw AaregException("Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: $e", e)
             }
         } else {
             return itererOverOrgtre(orgnrUnderenhet, orgledd.organisasjonsleddOver!![0].organisasjonsledd, idToken)
@@ -167,11 +165,10 @@ class InnsynService(
                         idPortenToken
                     )
                     if (arbeidsforhold is ArbeidsforholdFunnet) {
-                        logger.info("Klarte finne historiske arbeidsforhold")
                         return arbeidsforhold
                     }
                 } catch (e: Exception) {
-                    logger.error("klarte ikke hente historiske arbeidsforhold", e.message)
+                    logger.error("klarte ikke hente historiske arbeidsforhold $e", e)
                 }
             }
         }


### PR DESCRIPTION
ryddet i feilhåndtering slik at vi ikke lenger for dobbeltlogging og error logs på ting vi ikek kan gjøre noe med eller bryr oss om.

Ryddet også bort det vi fant av "død" kode. Dvs. kode som aldri vil skje pga hvordan resttemplate er konfigurert