### PR TITLE
litt refactoring og la top level bestemme log nivå

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <kotlin.version>1.4.32</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
         <token-support.version>1.3.7</token-support.version>
         <!-- overstyrt fra tokensupport i påvente av ny versjon https://github.com/navikt/token-support/issues/276 -->
         <nimbus-jose-jwt.version>8.20</nimbus-jose-jwt.version>
@@ -36,8 +36,8 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>1.4.3</version>
+            <artifactId>kotlinx-coroutines-jdk8</artifactId>
+            <version>1.5.0</version>
         </dependency>
 
 

--- a/src/main/kotlin/no/nav/tag/innsynAareg/models/ArbeidsforholdOppslagResultat.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/models/ArbeidsforholdOppslagResultat.kt
@@ -2,11 +2,11 @@ package no.nav.tag.innsynAareg.models
 
 import no.nav.tag.innsynAareg.client.aareg.dto.OversiktOverArbeidsForhold
 
-sealed class ArbeidsforholdOppslagResultat
+sealed interface ArbeidsforholdOppslagResultat
 
-object IngenRettigheter : ArbeidsforholdOppslagResultat()
+object IngenRettigheter : ArbeidsforholdOppslagResultat
 
 data class ArbeidsforholdFunnet(
     val oversiktOverArbeidsForhold: OversiktOverArbeidsForhold
-) : ArbeidsforholdOppslagResultat()
+) : ArbeidsforholdOppslagResultat
 

--- a/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
@@ -113,29 +113,28 @@ class InnsynService(
         idPortenToken: String,
         fnr: String
     ): ArbeidsforholdOppslagResultat {
-        val oversiktOverArbeidsforhold = aaregClient.hentArbeidsforhold(
+
+        var oversiktOverArbeidsforhold = aaregClient.hentArbeidsforhold(
             bedriftsnr,
             overOrdnetEnhetOrgnr,
             idPortenToken
         )
 
-        return oversiktOverArbeidsforhold.let {
-            when(it) {
-                is IngenRettigheter -> {
-                    finnOpplysningspliktigOgHentArbeidsforhold(
-                        bedriftsnr,
-                        overOrdnetEnhetOrgnr,
-                        idPortenToken,
-                        fnr
-                    )
-                }
-                is ArbeidsforholdFunnet -> {
-                    navneoppslagService.settNavn(it.oversiktOverArbeidsForhold)
-                    settYrkeskodebetydningPaAlleArbeidsforhold(it.oversiktOverArbeidsForhold)
-                    it
-                }
-            }
+        if (oversiktOverArbeidsforhold !is ArbeidsforholdFunnet) {
+            oversiktOverArbeidsforhold = finnOpplysningspliktigOgHentArbeidsforhold(
+                bedriftsnr,
+                overOrdnetEnhetOrgnr,
+                idPortenToken,
+                fnr
+            )
         }
+
+        if (oversiktOverArbeidsforhold is ArbeidsforholdFunnet) {
+            navneoppslagService.settNavn(oversiktOverArbeidsforhold.oversiktOverArbeidsForhold)
+            settYrkeskodebetydningPaAlleArbeidsforhold(oversiktOverArbeidsforhold.oversiktOverArbeidsForhold)
+        }
+
+        return oversiktOverArbeidsforhold
     }
 
 

--- a/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
@@ -120,7 +120,7 @@ class InnsynService(
             idPortenToken
         )
 
-        if (oversiktOverArbeidsforhold !is ArbeidsforholdFunnet) {
+        if (oversiktOverArbeidsforhold is IngenRettigheter) {
             oversiktOverArbeidsforhold = finnOpplysningspliktigOgHentArbeidsforhold(
                 bedriftsnr,
                 overOrdnetEnhetOrgnr,

--- a/src/test/kotlin/no/nav/tag/innsynAareg/client/aareg/AaregClientTest.kt
+++ b/src/test/kotlin/no/nav/tag/innsynAareg/client/aareg/AaregClientTest.kt
@@ -8,7 +8,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Answers
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient


### PR DESCRIPTION
det er fortsatt litt støy i loggene relatert 40x.
endrer slik at klienten ikke oversetter alle restclient exceptions til Runtime exception, slik at top level kan logge riktig basert på exception type. 
prøvde meg på en refactoring i samme slengen når jeg først var inne her
