### PR TITLE
vis 0 i stedet for å feile med nullpointerexception

### DIFF
--- a/src/main/kotlin/no/nav/tag/innsynAareg/controller/AaregController.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/controller/AaregController.kt
@@ -62,7 +62,7 @@ class AaregController(
         @RequestHeader("orgnr") orgnr: String,
         @RequestHeader("jurenhet") juridiskEnhetOrgnr: String,
         @ApiIgnore @CookieValue("selvbetjening-idtoken") idToken: String
-    ): Pair<String, Number> =
+    ): Pair<String, Number?> =
         aAregService.hentAntallArbeidsforholdPåUnderenhet(
             orgnr,
             juridiskEnhetOrgnr,

--- a/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
@@ -28,7 +28,7 @@ class InnsynService(
         orgnrUnderenhet: String,
         orgnrHovedenhet: String,
         idPortenToken: String
-    ): Pair<String, Int> {
+    ): Pair<String, Int?> {
         val antall: Int? = aaregClient.antallArbeidsforholdForOpplysningspliktig(
             orgnrUnderenhet,
             orgnrHovedenhet,
@@ -61,7 +61,7 @@ class InnsynService(
         orgnrUnderenhet: String,
         orgledd: OrganisasjonFraEreg,
         idToken: String
-    ): Pair<String, Int> {
+    ): Pair<String, Int?> {
         val antall = aaregClient.antallArbeidsforholdForOpplysningspliktig(
             orgnrUnderenhet,
             orgledd.organisasjonsnummer,
@@ -78,7 +78,7 @@ class InnsynService(
                     juridiskEnhetOrgnr,
                     idToken
                 )
-                return Pair(juridiskEnhetOrgnr, antallNesteNiva?:0)
+                return Pair(juridiskEnhetOrgnr, antallNesteNiva)
             } catch (e: Exception) {
                 throw AaregException("Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: $e", e)
             }

--- a/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/tag/innsynAareg/service/InnsynService.kt
@@ -78,7 +78,7 @@ class InnsynService(
                     juridiskEnhetOrgnr,
                     idToken
                 )
-                return Pair(juridiskEnhetOrgnr, antallNesteNiva!!)
+                return Pair(juridiskEnhetOrgnr, antallNesteNiva?:0)
             } catch (e: Exception) {
                 throw AaregException("Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: $e", e)
             }


### PR DESCRIPTION
usikker på om dette er beste fiks, men per nå feiler det hardt med nullpointerexception

* https://github.com/navikt/arbeidsgiver-innsyn-aareg/pull/446

```
no.nav.tag.innsynAareg.client.aareg.AaregException: Aareg Exception, klarte ikke finne opplysningspliktig: no.nav.tag.innsynAareg.client.aareg.AaregException: Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: java.lang.NullPointerException
	at no.nav.tag.innsynAareg.service.InnsynService.hentAntallArbeidsforholdPåUnderenhet(InnsynService.kt:56)
	at no.nav.tag.innsynAareg.controller.AaregController.hentAntallArbeidsforhold(AaregController.kt:66)
	at jdk.internal.reflect.GeneratedMethodAccessor70.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:197)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:141)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:106)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:893)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:807)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1061)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:961)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:626)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:733)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at no.nav.security.token.support.filter.JwtTokenValidationFilter.doTokenValidation(JwtTokenValidationFilter.java:51)
	at no.nav.security.token.support.filter.JwtTokenValidationFilter.doFilter(JwtTokenValidationFilter.java:35)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:747)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:374)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1590)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: no.nav.tag.innsynAareg.client.aareg.AaregException: Aareg Exception, feilet å finne antall arbeidsforhold på øverste nivå: java.lang.NullPointerException
	at no.nav.tag.innsynAareg.service.InnsynService.itererOverOrgtre(InnsynService.kt:83)
	at no.nav.tag.innsynAareg.service.InnsynService.hentAntallArbeidsforholdPåUnderenhet(InnsynService.kt:50)
	... 55 common frames omitted
Caused by: java.lang.NullPointerException: null
	at no.nav.tag.innsynAareg.service.InnsynService.itererOverOrgtre(InnsynService.kt:81)
	... 56 common frames omitted

```