### PR TITLE
bump proxy klient for å få bort intermittent parseerror

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>no.nav.arbeidsgiver</groupId>
             <artifactId>altinn-rettigheter-proxy-klient</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.7-rc</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
kommer fortsatt noen parseerror innimellom. Ser ut som vi kanskje har fikset det [etter 2.0.4](https://github.com/navikt/altinn-rettigheter-proxy-klient/compare/altinn-rettigheter-proxy-klient-2.0.4...altinn-rettigheter-proxy-klient-2.0.7-rc) 

Litt på siden så kommer det noen ganger alerts på log.error i innsyn-aareg-api uten at jeg finner det igjen i loggen 🤔 
Se f.eks: https://nav-it.slack.com/archives/G01KA7H11C5/p1641468463000500
Den tilsier at det burde være error i loggen i dag, men [søk i kibana](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1w,to:now))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:application,negate:!f,params:(query:innsyn-aareg-api),type:phrase),query:(match_phrase:(application:innsyn-aareg-api))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:level,negate:!f,params:!(Error),type:phrases,value:Error),query:(bool:(minimum_should_match:1,should:!((match_phrase:(level:Error))))))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:kuery,query:''),sort:!())) gir ikke treff i dag? 